### PR TITLE
Fix filter modal positioning and improve UI styling

### DIFF
--- a/attractions.js
+++ b/attractions.js
@@ -72,16 +72,16 @@ const renderFiltersAndSorts = (container, data) => {
             </div>
             <div class="mb-4">
                 <h4 class="text-lg font-bold mb-2">Filter by Rating</h4>
-                <div class="flex flex-wrap gap-2" id="rating-filters">
-                    <label class="flex items-center space-x-2 text-gray-700">
+                <div class="amenity-grid" id="rating-filters">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="rating-filter" value="4" class="form-radio h-4 w-4 text-blue-600">
                         <span>4+ <i class="fas fa-star text-yellow-400"></i></span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="rating-filter" value="4.5" class="form-radio h-4 w-4 text-blue-600">
                         <span>4.5+ <i class="fas fa-star text-yellow-400"></i></span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="rating-filter" value="5" class="form-radio h-4 w-4 text-blue-600">
                         <span>5 <i class="fas fa-star text-yellow-400"></i></span>
                     </label>
@@ -89,12 +89,12 @@ const renderFiltersAndSorts = (container, data) => {
             </div>
             <div class="mb-4">
                 <h4 class="text-lg font-bold mb-2">Sort</h4>
-                <div class="flex flex-wrap gap-2" id="sort-options">
-                    <label class="flex items-center space-x-2 text-gray-700">
+                <div class="amenity-grid" id="sort-options">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="sort-option" value="rating-desc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Rating (High to Low)</span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="sort-option" value="rating-asc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Rating (Low to High)</span>
                     </label>

--- a/attractions.js
+++ b/attractions.js
@@ -56,7 +56,7 @@ const renderFiltersAndSorts = (container, data) => {
     };
     const uniqueTypes = [...new Set(data.map(item => item.type).filter(Boolean))];
     const typeOptionsHtml = uniqueTypes.map(type => `
-        <label class="flex items-center space-x-2 text-gray-700 capitalize">
+        <label class="amenity-option flex items-center gap-2 text-gray-700 capitalize">
             <input type="checkbox" name="type-filter" value="${type}" class="form-checkbox h-4 w-4 text-blue-600 rounded">
             <span>${typeAliases[type] || type}</span>
         </label>
@@ -66,7 +66,7 @@ const renderFiltersAndSorts = (container, data) => {
         <div class="p-4">
             <div class="mb-4">
                 <h4 class="text-lg font-bold mb-2">Filter by Type</h4>
-                <div class="grid grid-cols-2 gap-2" id="type-filters">
+                <div class="amenity-grid" id="type-filters">
                     ${typeOptionsHtml}
                 </div>
             </div>

--- a/attractions.js
+++ b/attractions.js
@@ -153,18 +153,22 @@ export const renderAttractions = (data, isMobile, chatMessages) => {
         <div id="attractions-container" class="carousel flex overflow-x-auto snap-x snap-mandatory space-x-4 pb-4">
             ${data.map(getCardHtml).join('')}
         </div>
-        <div class="filter-modal fixed inset-0 modal-backdrop flex items-center justify-center p-4 z-50 hidden">
-            <div class="bg-white rounded-lg shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto relative">
-                <button class="close-modal absolute top-3 right-3 text-gray-400 hover:text-gray-600 text-2xl font-bold">×</button>
-                <h3 class="text-xl font-bold p-4 border-b">Filters & Sorts</h3>
-                <div id="filter-modal-content"></div>
+        <div class="filter-modal absolute inset-0 modal-backdrop z-50 hidden">
+            <div class="modal-panel w-full h-full p-3 sm:p-4">
+                <div class="bg-white rounded-2xl shadow-xl w-full h-full overflow-hidden flex flex-col">
+                    <div class="modal-header sticky top-0 flex items-center justify-between px-4 py-3 border-b bg-white">
+                        <h3 class="text-lg font-semibold">Filters & Sorts</h3>
+                        <button class="close-modal text-gray-400 hover:text-gray-600 text-2xl font-bold leading-none">×</button>
+                    </div>
+                    <div class="modal-body flex-1 overflow-y-auto px-4 py-4" id="filter-modal-content"></div>
+                </div>
             </div>
         </div>
     `;
 
     const bubble = document.createElement('div');
     bubble.className = `flex justify-start my-4 ${isMobile ? '' : 'w-full'}`;
-    bubble.innerHTML = `<div class="bg-white p-6 rounded-2xl shadow-md w-full">${mainHtml}</div>`;
+    bubble.innerHTML = `<div class="bg-white p-6 rounded-2xl shadow-md w-full relative">${mainHtml}</div>`;
     chatMessages.appendChild(bubble);
 
     const filterModalContent = bubble.querySelector('#filter-modal-content');

--- a/attractions.js
+++ b/attractions.js
@@ -153,7 +153,7 @@ export const renderAttractions = (data, isMobile, chatMessages) => {
         <div id="attractions-container" class="carousel flex overflow-x-auto snap-x snap-mandatory space-x-4 pb-4">
             ${data.map(getCardHtml).join('')}
         </div>
-        <div class="filter-modal fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center p-4 z-50 hidden">
+        <div class="filter-modal fixed inset-0 modal-backdrop flex items-center justify-center p-4 z-50 hidden">
             <div class="bg-white rounded-lg shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto relative">
                 <button class="close-modal absolute top-3 right-3 text-gray-400 hover:text-gray-600 text-2xl font-bold">×</button>
                 <h3 class="text-xl font-bold p-4 border-b">Filters & Sorts</h3>

--- a/flights.js
+++ b/flights.js
@@ -69,7 +69,7 @@ const renderFlightsInPlace = (filteredData) => {
 const renderFiltersAndSorts = (container, data) => {
     const allAirlines = [...new Set(data.map(flight => flight.airline).filter(Boolean))].sort();
     const airlineOptionsHtml = allAirlines.map(airline => `
-        <label class="flex items-center space-x-2 text-gray-700">
+        <label class="amenity-option flex items-center gap-2 text-gray-700">
             <input type="checkbox" name="airline-filter" value="${airline}" class="form-checkbox h-4 w-4 text-blue-600 rounded">
             <span>${airline}</span>
         </label>
@@ -79,34 +79,34 @@ const renderFiltersAndSorts = (container, data) => {
         <div class="p-4">
             <div class="mb-4">
                 <h4 class="text-lg font-bold mb-2">Filter by Airline</h4>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-1 max-h-32 overflow-y-auto" id="airline-filters">
+                <div class="amenity-grid mt-1 max-h-32 overflow-y-auto" id="airline-filters">
                     ${airlineOptionsHtml}
                 </div>
             </div>
             <div class="mb-4">
                 <h4 class="text-lg font-bold mb-2">Sort by:</h4>
-                <div class="flex flex-wrap gap-2" id="flight-sorts">
-                    <label class="flex items-center space-x-2 text-gray-700">
+                <div class="amenity-grid" id="flight-sorts">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="flight-sort" value="price-asc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Price (Low to High)</span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="flight-sort" value="price-desc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Price (High to Low)</span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="flight-sort" value="duration-asc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Duration (Shortest)</span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="flight-sort" value="duration-desc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Duration (Longest)</span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="flight-sort" value="departure-asc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Departure (Earliest)</span>
                     </label>
-                    <label class="flex items-center space-x-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="flight-sort" value="departure-desc" class="form-radio h-4 w-4 text-blue-600">
                         <span>Departure (Latest)</span>
                     </label>

--- a/flights.js
+++ b/flights.js
@@ -170,7 +170,7 @@ export const renderFlights = (data, isMobile, chatMessages) => {
         <div id="flights-container" class="carousel flex overflow-x-auto snap-x snap-mandatory space-x-4 pb-4">
             ${data.map(getCardHtml).join('')}
         </div>
-        <div class="filter-modal fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center p-4 z-50 hidden">
+        <div class="filter-modal fixed inset-0 modal-backdrop flex items-center justify-center p-4 z-50 hidden">
             <div class="bg-white rounded-lg shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto relative">
                 <button class="close-modal absolute top-3 right-3 text-gray-400 hover:text-gray-600 text-2xl font-bold">×</button>
                 <h3 class="text-xl font-bold p-4 border-b">Filters & Sorts</h3>

--- a/flights.js
+++ b/flights.js
@@ -170,18 +170,22 @@ export const renderFlights = (data, isMobile, chatMessages) => {
         <div id="flights-container" class="carousel flex overflow-x-auto snap-x snap-mandatory space-x-4 pb-4">
             ${data.map(getCardHtml).join('')}
         </div>
-        <div class="filter-modal fixed inset-0 modal-backdrop flex items-center justify-center p-4 z-50 hidden">
-            <div class="bg-white rounded-lg shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto relative">
-                <button class="close-modal absolute top-3 right-3 text-gray-400 hover:text-gray-600 text-2xl font-bold">×</button>
-                <h3 class="text-xl font-bold p-4 border-b">Filters & Sorts</h3>
-                <div id="filter-modal-content"></div>
+        <div class="filter-modal absolute inset-0 modal-backdrop z-50 hidden">
+            <div class="modal-panel w-full h-full p-3 sm:p-4">
+                <div class="bg-white rounded-2xl shadow-xl w-full h-full overflow-hidden flex flex-col">
+                    <div class="modal-header sticky top-0 flex items-center justify-between px-4 py-3 border-b bg-white">
+                        <h3 class="text-lg font-semibold">Filters & Sorts</h3>
+                        <button class="close-modal text-gray-400 hover:text-gray-600 text-2xl font-bold leading-none">×</button>
+                    </div>
+                    <div class="modal-body flex-1 overflow-y-auto px-4 py-4" id="filter-modal-content"></div>
+                </div>
             </div>
         </div>
     `;
 
     const bubble = document.createElement('div');
     bubble.className = `flex justify-start my-4 ${isMobile ? '' : 'w-full'}`;
-    bubble.innerHTML = `<div class="bg-white p-6 rounded-2xl shadow-md w-full">${mainHtml}</div>`;
+    bubble.innerHTML = `<div class="bg-white p-6 rounded-2xl shadow-md w-full relative">${mainHtml}</div>`;
     chatMessages.appendChild(bubble);
 
     const filterModalContent = bubble.querySelector('#filter-modal-content');

--- a/hotels.js
+++ b/hotels.js
@@ -89,7 +89,7 @@ const renderHotelsInPlace = (filteredData) => {
 const renderFiltersAndSorts = (container, data) => {
     const allAmenities = [...new Set(data.flatMap(hotel => hotel.amenities || []).filter(Boolean))].sort();
     const amenitiesOptionsHtml = allAmenities.map(amenity => `
-        <label class="flex items-center gap-2 text-gray-700">
+        <label class="amenity-option flex items-center gap-2 text-gray-700">
             <input type="checkbox" name="amenity" value="${amenity}" class="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500">
             <span class="text-sm">${amenity}</span>
         </label>
@@ -99,7 +99,7 @@ const renderFiltersAndSorts = (container, data) => {
         <div class="space-y-6">
             <div>
                 <h4 class="text-base font-semibold mb-3">Filter by Amenities</h4>
-                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" id="amenity-filters">
+                <div class="amenity-grid" id="amenity-filters">
                     ${amenitiesOptionsHtml}
                 </div>
             </div>
@@ -194,7 +194,7 @@ export const renderHotels = (data, isMobile, chatMessages) => {
         <div id="hotels-container" class="carousel flex overflow-x-auto snap-x snap-mandatory space-x-4 pb-4">
             ${data.map(getCardHtml).join('')}
         </div>
-        <div class="filter-modal absolute inset-0 bg-black/50 z-50 hidden">
+        <div class="filter-modal absolute inset-0 modal-backdrop z-50 hidden">
             <div class="modal-panel w-full h-full p-3 sm:p-4">
                 <div class="bg-white rounded-2xl shadow-xl w-full h-full overflow-hidden flex flex-col">
                     <div class="modal-header sticky top-0 flex items-center justify-between px-4 py-3 border-b bg-white">

--- a/hotels.js
+++ b/hotels.js
@@ -41,8 +41,8 @@ const getCardHtml = (hotel) => {
         : imageComingSoon;
     const amenitiesHtml = !hotel.amenities || hotel.amenities[0] == null ? [] : hotel.amenities.map(amenity => `
         <span class="flex items-center space-x-2 text-xs text-gray-200">
-            <i class="${getAmenityIcon(amenity)}"></i>
-            <span>${amenity}</span>
+            <i class="{getAmenityIcon(amenity)}"></i>
+            <span>₹{amenity}</span>
         </span>
     `).join('');
 

--- a/hotels.js
+++ b/hotels.js
@@ -106,15 +106,15 @@ const renderFiltersAndSorts = (container, data) => {
             <div>
                 <h4 class="text-base font-semibold mb-3">Filter by Rating</h4>
                 <div class="flex flex-wrap gap-4" id="rating-filters">
-                    <label class="flex items-center gap-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="rating-filter" value="4" class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500">
                         <span class="text-sm">4+ <i class="fas fa-star text-yellow-400"></i></span>
                     </label>
-                    <label class="flex items-center gap-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="rating-filter" value="4.5" class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500">
                         <span class="text-sm">4.5+ <i class="fas fa-star text-yellow-400"></i></span>
                     </label>
-                    <label class="flex items-center gap-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="rating-filter" value="5" class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500">
                         <span class="text-sm">5 <i class="fas fa-star text-yellow-400"></i></span>
                     </label>
@@ -122,20 +122,20 @@ const renderFiltersAndSorts = (container, data) => {
             </div>
             <div>
                 <h4 class="text-base font-semibold mb-3">Sort</h4>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3" id="sort-options">
-                    <label class="flex items-center gap-2 text-gray-700">
+                <div class="amenity-grid" id="sort-options">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="sort-option" value="price-asc" class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500">
                         <span class="text-sm">Price (Low to High)</span>
                     </label>
-                    <label class="flex items-center gap-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="sort-option" value="price-desc" class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500">
                         <span class="text-sm">Price (High to Low)</span>
                     </label>
-                    <label class="flex items-center gap-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="sort-option" value="rating-desc" class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500">
                         <span class="text-sm">Rating (High to Low)</span>
                     </label>
-                    <label class="flex items-center gap-2 text-gray-700">
+                    <label class="amenity-option flex items-center gap-2 text-gray-700">
                         <input type="radio" name="sort-option" value="rating-asc" class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500">
                         <span class="text-sm">Rating (Low to High)</span>
                     </label>

--- a/hotels.js
+++ b/hotels.js
@@ -42,7 +42,7 @@ const getCardHtml = (hotel) => {
     const amenitiesHtml = !hotel.amenities || hotel.amenities[0] == null ? [] : hotel.amenities.map(amenity => `
         <span class="flex items-center space-x-2 text-xs text-gray-200">
             <i class="{getAmenityIcon(amenity)}"></i>
-            <span>₹{amenity}</span>
+            <span>${amenity}</span>
         </span>
     `).join('');
 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             </div>
         </div>
     
-        <div id="chat-container" class="bg-gray-200 phone-view flex-grow flex flex-col overflow-hidden transition-all duration-700 ease-in-out shadow-2xl mx-auto z-20">
+        <div id="chat-container" class="bg-gray-200 phone-view flex-grow flex flex-col overflow-hidden transition-all duration-700 ease-in-out shadow-2xl chat-right-align z-20">
             <div class="relative bg-white shadow-md rounded-t-2xl p-4 flex items-center justify-between z-10">
                 <div class="flex items-center space-x-3">
                     <div class="bg-blue-500 w-10 h-10 rounded-full flex items-center justify-center text-white font-bold text-lg">

--- a/main.js
+++ b/main.js
@@ -140,20 +140,20 @@ toggleButton.addEventListener('click', () => {
         showModal("The desktop view is available on larger screens.");
         return;
     }
-    
+
     isDesktopView = !isDesktopView;
     if (isDesktopView) {
-        chatContainer.classList.add('desktop-view');
-        chatContainer.classList.remove('phone-view');
+        chatContainer.classList.add('desktop-view', 'chat-centered');
+        chatContainer.classList.remove('phone-view', 'chat-right-align');
         introSection.classList.add('hide-intro');
         toggleButton.innerHTML = '<i class="fas fa-mobile-alt text-sm"></i>';
     } else {
-        chatContainer.classList.remove('desktop-view');
-        chatContainer.classList.add('phone-view');
+        chatContainer.classList.remove('desktop-view', 'chat-centered');
+        chatContainer.classList.add('phone-view', 'chat-right-align');
         introSection.classList.remove('hide-intro');
         toggleButton.innerHTML = '<i class="fas fa-desktop text-sm"></i>';
     }
-    
+
     const messages = [...chatMessages.children];
     chatMessages.innerHTML = '';
     messages.forEach(msg => chatMessages.appendChild(msg));
@@ -165,8 +165,11 @@ window.addEventListener('load', () => {
     if (window.innerWidth >= 768) {
         chatContainer.classList.add('transition-width');
         introSection.classList.add('transition-all');
-        isDesktopView = true;
-        toggleButton.innerHTML = '<i class="fas fa-mobile-alt text-sm"></i>';
+        isDesktopView = false;
+        chatContainer.classList.add('phone-view', 'chat-right-align');
+        chatContainer.classList.remove('desktop-view', 'chat-centered');
+        introSection.classList.remove('hide-intro');
+        toggleButton.innerHTML = '<i class="fas fa-desktop text-sm"></i>';
     } else {
         isDesktopView = false;
         chatContainer.classList.add('phone-view');

--- a/style.css
+++ b/style.css
@@ -484,6 +484,10 @@ input[type="checkbox"]:checked + .collapse-title:after {
     max-width: none !important;
 }
 
+/* Chat alignment helpers */
+.chat-right-align { margin-left: auto; }
+.chat-centered { margin-left: auto; margin-right: auto; }
+
 /* Custom modal backdrop: light, subtle blur instead of dark overlay */
 .modal-backdrop {
   background-color: rgba(255, 255, 255, 0.35);

--- a/style.css
+++ b/style.css
@@ -483,3 +483,34 @@ input[type="checkbox"]:checked + .collapse-title:after {
     width: 100% !important;
     max-width: none !important;
 }
+
+/* Custom modal backdrop: light, subtle blur instead of dark overlay */
+.modal-backdrop {
+  background-color: rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(4px);
+}
+
+/* Responsive, modern grid for amenity checkboxes */
+.amenity-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .amenity-grid {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  }
+}
+
+/* Pill-style option for better spacing and non-overlap */
+.amenity-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  line-height: 1.25;
+}


### PR DESCRIPTION
## Purpose
The user wanted to improve the chatbot interface by:
- Moving filter modals from appearing outside the chatbot to inside it (like hotel filters)
- Fixing overlapping content in filter sections with proper spacing
- Making filter UI more modern and stylish
- Positioning the chat interface on the right side in mobile view and center in desktop view
- Removing dark background overlay from filter popups

## Code changes
- **Modal positioning**: Changed filter modals from `fixed` to `absolute` positioning to contain them within the chatbot interface
- **UI styling improvements**: 
  - Added `.amenity-grid` class with responsive grid layout for better spacing
  - Created `.amenity-option` pill-style components to prevent content overlap
  - Replaced dark modal backdrop with light, subtle blur effect
- **Chat alignment**: Added `.chat-right-align` and `.chat-centered` classes for proper positioning
- **Consistent styling**: Applied uniform styling across hotels, flights, and attractions filter components
- **Responsive design**: Improved grid layouts that adapt to different screen sizesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a70f26bb583a4f728967c6f9d1ff9673/pixel-hub)

👀 [Preview Link](https://a70f26bb583a4f728967c6f9d1ff9673-pixel-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a70f26bb583a4f728967c6f9d1ff9673</projectId>-->
<!--<branchName>pixel-hub</branchName>-->